### PR TITLE
dovecot: Remove autocreate plugin (for dovecot >= 2.1)

### DIFF
--- a/config/dovecot/dovecot.conf
+++ b/config/dovecot/dovecot.conf
@@ -1,4 +1,4 @@
-# 2.1.7: /etc/dovecot/dovecot.conf
+# 2.2.13: /etc/dovecot/dovecot.conf
 # OS: Linux 3.2.0-3-686-pae i686 Debian wheezy/sid ext4
 listen = *, ::
 auth_mechanisms = plain login
@@ -40,7 +40,7 @@ userdb {
 }
 protocol imap {
   imap_client_workarounds =
-  mail_plugins = $mail_plugins imap_quota antispam autocreate
+  mail_plugins = $mail_plugins imap_quota antispam
 }
 protocol lda {
   auth_socket_path = /var/run/dovecot/auth-master
@@ -67,8 +67,6 @@ plugin {
 }
 
 plugin {
-  autocreate = Trash
-  autocreate2 = Junk
   autosubscribe = Trash
   autosubscribe2 = Junk
 }


### PR DESCRIPTION
autocreate[1] plugin is now deprecated with dovecot >=2.1
this function is now implicit (autocreate is automatic if not
specified). We can manually configure autocreate features using
mailboxsettings[2] but it's not really needed in our case.

this patch fixes this error message:

```
Aug 16 12:15:40 test1 dovecot: imap(doge): Warning: autocreate plugin is deprecated, use mailbox { auto } setting instead
```

[1]http://wiki2.dovecot.org/Plugins/Autocreate
[2]http://wiki2.dovecot.org/MailboxSettings